### PR TITLE
修复event.persist is not a function错误

### DIFF
--- a/main/src/index.js
+++ b/main/src/index.js
@@ -64,7 +64,7 @@ class Echarts extends Component {
   }
 
   _handleMessage = (event) => {
-    event.persist()
+    //event.persist()
     if (!event) return null;
     const data = JSON.parse(event.nativeEvent.data)
     switch (data.types) {


### PR DESCRIPTION
在android上，若点击某个热点，会报event.persist is not a function错误，注释此行可修复